### PR TITLE
fix:nginx

### DIFF
--- a/cloud-music.conf
+++ b/cloud-music.conf
@@ -6,7 +6,8 @@ server{
         index index.html index.htm;
         try_files $uri $uri/ /index.html;
     }
-    location /api {
-        proxy_pass http://localhost:3000;
+    location /api/ {
+        rewrite  /api/(.*)  /$1  break;
+        proxy_pass http://106.52.178.229:3000;
     }
 }


### PR DESCRIPTION
添加一条重写规则，将 /api/{path} 转到目标服务的 /{path} 接口上